### PR TITLE
Add CSS file to define classes colors in the datacenter view

### DIFF
--- a/schirrms-generic-connection-to-datacenter-view/asset/css/default.scss
+++ b/schirrms-generic-connection-to-datacenter-view/asset/css/default.scss
@@ -1,0 +1,27 @@
+@import '../env-production/molkobain-datacenter-view/common/css/variables.scss';
+
+/* Variables */
+$obj-class-genericcommdevice-bg-color: $obj-class-networkdevice-bg-color !default;
+
+/* Rules */
+.molkobain-datacenter-view {
+	.mdv-body {
+		.mdv-controls {
+			.mdv-legend {
+				ul {
+					li {
+						&[data-class="GenericCommDevice"]::before {
+							background-color: $obj-class-genericcommdevice-bg-color;
+						}
+					}
+				}
+			}
+		}
+
+		.mdv-device {
+			&[data-class="GenericCommDevice"] {
+				background-color: $obj-class-genericcommdevice-bg-color;
+			}
+		}
+	}
+}

--- a/schirrms-generic-connection-to-datacenter-view/module.schirrms-generic-connection-to-datacenter-view.php
+++ b/schirrms-generic-connection-to-datacenter-view/module.schirrms-generic-connection-to-datacenter-view.php
@@ -24,7 +24,9 @@ SetupWebPage::AddModule(
 		// Components
 		//
 		'datamodel' => array(
-			'model.schirrms-generic-connection-to-datacenter-view.php'
+			'model.schirrms-generic-connection-to-datacenter-view.php',
+			// Explicitly load APIs classes
+			'src/Hook/Backoffice/PageUIExtension.php',
 		),
 		'webservice' => array(
 			

--- a/schirrms-generic-connection-to-datacenter-view/src/Hook/Backoffice/PageUIExtension.php
+++ b/schirrms-generic-connection-to-datacenter-view/src/Hook/Backoffice/PageUIExtension.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Schrimms\iTop\Extension\GenericConnectionToDatacenterView\Hook\Backoffice;
+
+use iTopWebPage;
+
+class PageUIExtension implements \iPageUIExtension
+{
+	const MODULE_CODE = 'schirrms-generic-connection-to-datacenter-view';
+
+	/**
+	 * @inheritDoc
+	 */
+	public function GetNorthPaneHtml(iTopWebPage $oPage)
+	{
+		$oPage->add_saas('env-'.\utils::GetCurrentEnvironment().'/'.static::MODULE_CODE.'/asset/css/default.scss');
+
+		return '';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function GetSouthPaneHtml(iTopWebPage $oPage)
+	{
+		// Do nothing
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function GetBannerHtml(iTopWebPage $oPage)
+	{
+		// Do nothing
+	}
+}


### PR DESCRIPTION
Hello Schrimms!

As discussed in the other [PR](https://github.com/Molkobain/itop-datacenter-view/pull/11), here is one to include the CSS directly in this great bridge module.

Cheers,
Guillaume